### PR TITLE
lwdOuter defaults to 0.5 instead of 0.

### DIFF
--- a/R/buildPlot.r
+++ b/R/buildPlot.r
@@ -47,7 +47,7 @@
 #'
 buildPlotting.default <- function(modelCI, 
                                   title="Coefficient Plot", 
-                                  xlab="Value", ylab="Coefficient", lwdInner=1, lwdOuter=0, pointSize=3,
+                                  xlab="Value", ylab="Coefficient", lwdInner=1, lwdOuter=0.5, pointSize=3,
                                   color="blue", cex=.8, textAngle=0, numberAngle=0, 
                                   shape=16, linetype=1,
                                   outerCI=2, innerCI=1, multi=FALSE, 

--- a/R/coefplot.r
+++ b/R/coefplot.r
@@ -121,7 +121,7 @@ coefplot <- function(model, ...)
 #' coefplot(model1, coefficients=c("(Intercept)", "color.Q"))
 #'
 coefplot.default <- function(model, title="Coefficient Plot", xlab="Value", ylab="Coefficient", 
-                             innerCI=1, outerCI=2, lwdInner=1, lwdOuter=0, pointSize=3,  color="blue", shape=16,
+                             innerCI=1, outerCI=2, lwdInner=1, lwdOuter=0.5, pointSize=3,  color="blue", shape=16,
                              cex=.8, textAngle=0, numberAngle=0,
                              zeroColor="grey", zeroLWD=1, zeroType=2,
                              facet=FALSE, scales="free",

--- a/R/multiplot.r
+++ b/R/multiplot.r
@@ -86,7 +86,7 @@
 #' 
 #'
 multiplot <- function(..., title="Coefficient Plot", xlab="Value", ylab="Coefficient", 
-    					innerCI=1, outerCI=2, lwdInner=1, lwdOuter=0, pointSize=3, dodgeHeight=1,  
+    					innerCI=1, outerCI=2, lwdInner=1, lwdOuter=0.5, pointSize=3, dodgeHeight=1,  
                       color="blue", shape=16, linetype=1,
 						cex=.8, textAngle=0, numberAngle=90,
 						zeroColor="grey", zeroLWD=1, zeroType=2,

--- a/man/buildPlotting.default.Rd
+++ b/man/buildPlotting.default.Rd
@@ -5,7 +5,7 @@
 \title{Coefplot plotting}
 \usage{
 buildPlotting.default(modelCI, title = "Coefficient Plot", xlab = "Value",
-  ylab = "Coefficient", lwdInner = 1, lwdOuter = 0, pointSize = 3,
+  ylab = "Coefficient", lwdInner = 1, lwdOuter = 0.5, pointSize = 3,
   color = "blue", cex = 0.8, textAngle = 0, numberAngle = 0,
   shape = 16, linetype = 1, outerCI = 2, innerCI = 1, multi = FALSE,
   zeroColor = "grey", zeroLWD = 1, zeroType = 2, numeric = FALSE,

--- a/man/coefplot.default.Rd
+++ b/man/coefplot.default.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{coefplot}{default}(model, title = "Coefficient Plot",
   xlab = "Value", ylab = "Coefficient", innerCI = 1, outerCI = 2,
-  lwdInner = 1, lwdOuter = 0, pointSize = 3, color = "blue",
+  lwdInner = 1, lwdOuter = 0.5, pointSize = 3, color = "blue",
   shape = 16, cex = 0.8, textAngle = 0, numberAngle = 0,
   zeroColor = "grey", zeroLWD = 1, zeroType = 2, facet = FALSE,
   scales = "free", sort = c("natural", "magnitude", "alphabetical"),

--- a/man/multiplot.Rd
+++ b/man/multiplot.Rd
@@ -6,7 +6,7 @@
 \usage{
 multiplot(..., title = "Coefficient Plot", xlab = "Value",
   ylab = "Coefficient", innerCI = 1, outerCI = 2, lwdInner = 1,
-  lwdOuter = 0, pointSize = 3, dodgeHeight = 1, color = "blue",
+  lwdOuter = 0.5, pointSize = 3, dodgeHeight = 1, color = "blue",
   shape = 16, linetype = 1, cex = 0.8, textAngle = 0,
   numberAngle = 90, zeroColor = "grey", zeroLWD = 1, zeroType = 2,
   single = TRUE, scales = "fixed", ncol = length(unique(modelCI$Model)),


### PR DESCRIPTION
With the previous default of lwdOuter at 0 no line was shown, although the
definition of the outerCI was 2, and it did not make much sense to define the
width of the outer interval but not have it plotted. With this new default a
line half the width of the inner will be shown.
