### PR TITLE
`funs()` function, deprecated in `{dplyr}` 0.8.0, has been modified so that it is not used and warning messages are not displayed.

### DIFF
--- a/R/buildPlottingFrame.r
+++ b/R/buildPlottingFrame.r
@@ -126,10 +126,11 @@ buildModelCI.default <- function(model, outerCI=2, innerCI=1, intercept=TRUE, nu
     # perform a transformation on the numbers if it's not the identity
     if(!identical(trans, identity))
     {
-        modelCI <- dplyr::mutate_at(.tbl=modelCI, .funs=trans, 
-                                       .vars=c('Value', 
-                                              'HighInner', 'HighOuter', 
-                                              'LowInner', 'LowOuter'))
+        modelCI <- dplyr::mutate(.data=modelCI, 
+                                 dplyr::across(.cols=c('Value', 
+                                                       'HighInner', 'HighOuter', 
+                                                       'LowInner', 'LowOuter'), 
+                                               .fns=trans))
     }
 
     ## possible orderings of the coefficients


### PR DESCRIPTION
If I specify anything other than identity for the `trans` argument in `coefplot()`, I get the following warning message.

``` r
library(coefplot)

model2 <- glm(price > 10000 ~ carat + cut*color, data=diamonds, family=binomial(link="logit"))
coefplot(model2, trans=invlogit)

    ## Warning: `funs()` was deprecated in dplyr 0.8.0.
    ## Please use a list of either functions or lambdas: 
    ## 
    ##   # Simple named list: 
    ##   list(mean = mean, median = median)
    ## 
    ##   # Auto named with `tibble::lst()`: 
    ##   tibble::lst(mean, median)
    ## 
    ##   # Using lambdas
    ##   list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))
    ## This warning is displayed once every 8 hours.
    ## Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated.

# Figure omitted.

```

As you can see in the message, this is due to the use of `funs()`, which has been deprecated since `{dplyr}` 0.8.0.
Currently there is no problem with the result, but it is hoped that this will be corrected in the future, as deprecated functions may be removed in the future.

The code I pulled is expected to work as before without any warning messages.
If you do not like it, please discard it.